### PR TITLE
Enable `containercomponent` to be rendered from component definitions

### DIFF
--- a/packages/sdk/src/cms-components/core/container.js
+++ b/packages/sdk/src/cms-components/core/container.js
@@ -53,18 +53,18 @@ export default class CmsContainer extends React.Component {
     const ContainerComponent = componentDefinitions[label] && componentDefinitions[label].component;
 
     // if found then wrap container items with this component
-    if (!!ContainerComponent) {
-      return React.createElement(
-        ContainerComponent,
-        { configuration, pageModel, preview, componentDefinitions },
-        containerItemComponents
+    if (!ContainerComponent) {
+      return (
+        <React.Fragment>
+          { containerItemComponents }
+        </React.Fragment>
       );
     }
 
-    return (
-      <React.Fragment>
-        { containerItemComponents }
-      </React.Fragment>
+    return React.createElement(
+      ContainerComponent,
+      { configuration, pageModel, preview, componentDefinitions },
+      containerItemComponents
     );
   }
 

--- a/packages/sdk/src/cms-components/core/container.js
+++ b/packages/sdk/src/cms-components/core/container.js
@@ -40,14 +40,14 @@ export default class CmsContainer extends React.Component {
     const { components, label } = configuration;
 
     // don't render anything when there're no components found
-    if (!components || components.length === 0) {
+    if (!components || !components.length) {
       return null;
     }
 
     // get component item components
-    const containerItemComponents = components.map(component => {
-      return <CmsContainerItem configuration={component} key={component.id} />;
-    });
+    const containerItemComponents = components.map(component => (
+      <CmsContainerItem configuration={component} key={component.id} />
+    ));
 
     // check if component container is found in component definitions
     const ContainerComponent = componentDefinitions[label] && componentDefinitions[label].component;
@@ -63,8 +63,13 @@ export default class CmsContainer extends React.Component {
 
     return React.createElement(
       ContainerComponent,
-      { configuration, pageModel, preview, componentDefinitions },
-      containerItemComponents
+      {
+        configuration,
+        pageModel,
+        preview,
+        componentDefinitions,
+      },
+      containerItemComponents,
     );
   }
 

--- a/packages/sdk/src/cms-components/core/container.js
+++ b/packages/sdk/src/cms-components/core/container.js
@@ -54,13 +54,6 @@ export default class CmsContainer extends React.Component {
 
     // if found then wrap container items with this component
     if (!!ContainerComponent) {
-      const props = {
-        configuration: configuration,
-        pageModel: pageModel,
-        preview: preview,
-        componentDefinitions: componentDefinitions,
-      };
-
       return React.createElement(
         ContainerComponent,
         { configuration, pageModel, preview, componentDefinitions },

--- a/packages/sdk/src/utils/fetch.js
+++ b/packages/sdk/src/utils/fetch.js
@@ -24,7 +24,7 @@ const requestConfigGet = {
 
 const requestConfigPost = {
   method: 'POST',
-  credentials: true,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
   },


### PR DESCRIPTION
## Why 
The SDK didn't provide a way through component definitions to render `CONTAINER_COMPONENT` (only `CONTAINER_ITEM_COMPONENT` can be rendered). Container components are responsible for rendering layout (example; sidebar).

## Fix
Added a small improvement to add the ability to provide container components from the component definitions.

## Usage
```js
const Sidebar = ({ children}) => <aside className="sidebar">{children}</aside>;

const componentDefinitions = {
  'Sidebar Container': { component: Sidebar },
};
```