### PR TITLE
Resolve CMS-12083

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,11 @@ Parses date-field of a content item and returns date as a string.
 
 ## Release notes
 
+### Version 0.5.1
+- Fixed bug with preview update on the component properties dialog changes;
+- Fixed bug with preview update on save/discard changes from the component properties dialog;
+- Fixed bug with the manage content button keeps referring to the old content after saving changes in the dialog.
+
 ### Version 0.5.0
 - Fixed bug with SSO handshake in client-side rendered applications.
 

--- a/examples/client-side-rendered/package.json
+++ b/examples/client-side-rendered/package.json
@@ -4,7 +4,7 @@
   "description": "Example client-side React App for the BloomReach Experience SDK for React",
   "private": true,
   "dependencies": {
-    "bloomreach-experience-react-sdk": "^0.4.4",
+    "bloomreach-experience-react-sdk": "^0.5.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "react-router-dom": "^4.3.1",

--- a/examples/server-side-rendered/package.json
+++ b/examples/server-side-rendered/package.json
@@ -4,7 +4,7 @@
   "description": "Example server-side React App for the BloomReach Experience SDK for React",
   "private": true,
   "dependencies": {
-    "bloomreach-experience-react-sdk": "^0.4.4",
+    "bloomreach-experience-react-sdk": "^0.5.1",
     "isomorphic-unfetch": "^2.0.0",
     "next": "^6.1.1",
     "next-routes": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bloomreach-experience-react-sdk",
-  "version": "0.5.0-rc1",
+  "version": "0.5.1",
   "description": "BloomReach Experience SDK for React",
   "keywords": [
     "react",

--- a/src/cms-components/core/cms-edit-button.js
+++ b/src/cms-components/core/cms-edit-button.js
@@ -1,21 +1,53 @@
 import React from 'react';
 import { addBeginComment } from '../../utils/add-html-comment';
+import getNestedObject from '../../utils/get-nested-object';
 
 export default class CmsEditButton extends React.Component {
-  addButton(htmlElm, configuration, preview) {
+  constructor(props) {
+    super(props);
+
+    this.placeholder = React.createRef();
+  }
+
+  addButton(htmlElm) {
+    const { configuration, preview } = this.props;
     addBeginComment(htmlElm, 'afterbegin', configuration, preview);
   }
 
-  render() {
-    const { configuration, preview } = this.props;
+  shouldComponentUpdate(nextProps) {
+    const path = ['_meta', 'beginNodeSpan', 0, 'data'];
 
-    if (!preview) {
+    return getNestedObject(this.props.configuration, path) !== getNestedObject(nextProps.configuration, path);
+  }
+
+  componentDidMount() {
+    if (!this.placeholder.current) {
+      return;
+    }
+
+    this.addButton(this.placeholder.current);
+  }
+
+  componentDidUpdate() {
+    const placeholder = this.placeholder.current;
+    if (!placeholder) {
+      return;
+    }
+
+    Array.from(placeholder.childNodes)
+      .forEach(node => node.remove());
+    placeholder.removeAttribute('class');
+    this.addButton(placeholder);
+  }
+
+  render() {
+    if (!this.props.preview) {
       return null;
     }
 
     return (
       <div style={{ position: 'relative' }}>
-        <span ref={(editContentElm) => { this.addButton(editContentElm, configuration, preview); }}/>
+        <span ref={this.placeholder}/>
       </div>
     );
   }

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -22,9 +22,9 @@ export function fetchCmsPage(pathInfo, query, preview, cmsUrls) {
 }
 
 export function fetchComponentUpdate(pathInfo, query, preview, componentId, body) {
-  let requestConfig = Object.assign({}, requestConfigPost);
-  requestConfig.body = toUrlEncodedFormData(body);
+  const requestConfig = Object.assign({ data: toUrlEncodedFormData(body) }, requestConfigPost);
   const url = buildApiUrl(pathInfo, query, preview, componentId);
+
   return fetchUrl(url, requestConfig);
 }
 

--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -67,7 +67,7 @@ export function buildApiUrl(pathInfo, query, preview, componentId, cmsUrls) {
   }
   const [, ssoHandshake] = (query && query.match(SSO_HANDSHAKE)) || [];
   if (ssoHandshake) {
-    url += (url.indexOf('?') === -1 ? '?' : '') + ssoHandshake;
+    url += (url.indexOf('?') === -1 ? '?' : '&') + ssoHandshake;
   }
 
   return url;

--- a/src/utils/parse-request.js
+++ b/src/utils/parse-request.js
@@ -1,5 +1,4 @@
 import globalCmsUrls from './cms-urls';
-import 'core-js/fn/array/find-index';
 
 export default function parseRequest(request = {}, cmsUrls) {
   if (!cmsUrls) {


### PR DESCRIPTION
This pull-request fixes:
- Update preview on the component properties dialog changes;
- Update preview on save/discard changes from the component properties dialog;
- The manage content button keeps referring to the old content after saving changes in the dialog.