### PR TITLE
Extended support for NextJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ wrap any children of `<CmsPage>` in a function, as in the following example:
 }
  ```
 
-`<CmsPage>` takes two props: `componentDefinitions` and `request`.
+`<CmsPage>` takes three props: `componentDefinitions`, `request` and `noFetch`.
 
 The `request` prop is used to fetch the Page Model for the current page; and to detect whether 
 preview mode is active so that meta-data for Channel Manager functionality (e.g. in-context editing) is 
-included in the HTML, and consequently Channel Manager functionality is enabled.
+included in the HTML, and consequently Channel Manager functionality is enabled. When you application uses
+server-side rendering you might want to turn off the fetch functionality by setting the `noFetch` prop to
+true.
 
 Finally, component definitions are supplied through the `componentDefinitions` prop. The component 
 definitions tell `<RenderCmsComponent>` what React component to render by mapping these to the 
@@ -76,8 +78,9 @@ definitions tell `<RenderCmsComponent>` what React component to render by mappin
 ## Server-side rendering
 
 For server-side rendering (e.g. using [Next.js](https://github.com/zeit/next.js)) you need to fetch the 
-Page Model API server-side and supply it as a prop to `<CmsPage>`. Apart from this the usage is the same 
-as with client-side rendering.
+Page Model API server-side and supply it as a prop to `<CmsPage>`. If you want to have full control over the 
+request on every page load you have to set `noFetch` to true on the `<CmsPage>` component. Apart from this 
+the usage is the same as with client-side rendering.
 
 The helper function `getApiUrl()` can be used to generate the Page Model API URL using the current 
 request.

--- a/examples/server-side-rendered/package.json
+++ b/examples/server-side-rendered/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "bloomreach-experience-react-sdk": "^0.5.2",
     "isomorphic-unfetch": "^2.0.0",
-    "next": "^6.1.1",
+    "next": "^8.1.0",
     "next-routes": "^1.4.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1"

--- a/examples/server-side-rendered/pages/index.js
+++ b/examples/server-side-rendered/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Error from 'next/error';
 import Link from 'next/link';
-import { withRouter } from 'next/router';
+import Router, { withRouter } from 'next/router';
 
 import fetch from 'isomorphic-unfetch';
 import { getApiUrl, CmsPage, RenderCmsComponent } from 'bloomreach-experience-react-sdk';
@@ -58,16 +58,35 @@ export class Index extends React.Component {
     };
   }
 
+  setLoading = () => {
+    this.setState({ loading: true })
+  }
+
+  unsetLoading = () => {
+    this.setState({ loading: false })
+  }
+
+  componentWillMount() {
+    Router.events.on('routeChangeStart', this.setLoading)
+    Router.events.on('routeChangeComplete', this.unsetLoading)
+  }
+
+  componentWillUnmount() {
+    Router.events.off('routeChangeStart', this.setLoading)
+    Router.events.off('routeChangeComplete', this.unsetLoading)
+  }
+
   render () {
     const { errorCode, request, router } = this.props;
-
+    cons
+    
     if (errorCode) {
       return (<Error statusCode={errorCode} />);
     }
 
     return (
       <CmsPage componentDefinitions={componentDefinitions} cmsUrls={cmsUrls} pageModel={this.props.pageModel}
-               request={request} createLink={createLink}>
+               request={request} createLink={createLink} noFetch>
         { () =>
           <React.Fragment>
             <div id='header'>
@@ -83,7 +102,8 @@ export class Index extends React.Component {
               </nav>
             </div>
             <div className='container marketing'>
-              <RenderCmsComponent />
+              {loading ? <p>...Loading</p>
+              : <RenderCmsComponent />}
             </div>
           </React.Fragment>
         }

--- a/examples/server-side-rendered/pages/index.js
+++ b/examples/server-side-rendered/pages/index.js
@@ -26,6 +26,10 @@ const createLink = (href, linkText, className) => {
 };
 
 export class Index extends React.Component {
+  state = {
+    loading: false
+  }
+
   static async getInitialProps ({ req, asPath }) {
     // setting pageModel to empty list instead of null value,
     // as otherwise the API will be fetched client-side again after server-side fetch errors
@@ -66,7 +70,7 @@ export class Index extends React.Component {
     this.setState({ loading: false })
   }
 
-  componentWillMount() {
+  componentDidMount() {
     Router.events.on('routeChangeStart', this.setLoading)
     Router.events.on('routeChangeComplete', this.unsetLoading)
   }
@@ -78,8 +82,8 @@ export class Index extends React.Component {
 
   render () {
     const { errorCode, request, router } = this.props;
-    cons
-    
+    const { loading } = this.state
+
     if (errorCode) {
       return (<Error statusCode={errorCode} />);
     }

--- a/src/cms-components/core/page.js
+++ b/src/cms-components/core/page.js
@@ -121,9 +121,15 @@ export default class CmsPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props.request.path !== prevProps.request.path) {
-      const parsedUrl = this.parseRequest(this.props.request);
-      this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview);
+    if(!this.props.noFetch) {
+      if (this.props.request.path !== prevProps.request.path) {
+        const parsedUrl = this.parseRequest(this.props.request);
+        this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview);
+      }
+    } else {
+      if(this.props.pageModel !== prevProps.pageModel) {
+        this.setState({pageModel: this.props.pageModel})
+      }
     }
 
     if (this.state.pageModel !== prevState.pageModel && this.cms) {
@@ -134,7 +140,7 @@ export default class CmsPage extends React.Component {
   componentDidMount() {
     this.initializeCmsIntegration();
     // fetch page model if not supplied
-    if (!this.state.pageModel) {
+    if (!this.props.noFetch && !this.state.pageModel) {
       this.fetchPageModel(this.state.path, this.state.query, this.state.preview);
     } else {
       // add body comments client-side as document variable is undefined server-side

--- a/src/cms-components/core/page.js
+++ b/src/cms-components/core/page.js
@@ -128,7 +128,7 @@ export default class CmsPage extends React.Component {
       }
     } else {
       if(this.props.pageModel !== prevProps.pageModel) {
-        this.setState({pageModel: this.props.pageModel})
+        this.updatePageModel(this.props.pageModel)
       }
     }
 

--- a/src/cms-components/core/page.js
+++ b/src/cms-components/core/page.js
@@ -121,19 +121,19 @@ export default class CmsPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if(!this.props.noFetch) {
+    if (!this.props.noFetch) {
       if (this.props.request.path !== prevProps.request.path) {
-        const parsedUrl = this.parseRequest(this.props.request);
-        this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview);
+        const parsedUrl = this.parseRequest(this.props.request)
+        this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview)
       }
     } else {
-      if(this.props.pageModel !== prevProps.pageModel) {
+      if (this.props.pageModel !== prevProps.pageModel) {
         this.updatePageModel(this.props.pageModel)
       }
     }
 
     if (this.state.pageModel !== prevState.pageModel && this.cms) {
-      this.cms.createOverlay();
+      this.cms.syncOverlay()
     }
   }
 


### PR DESCRIPTION
I have added a NoFetch prop on the page Hoc to add extended support for NextJS and Next Router.
I changed one createOverlay call to syncOverlay as is was resulting in an infinite loop during a component update in our setup.
Updates are available in the example project.