### PR TITLE
Server Side Rendering

### DIFF
--- a/packages/sdk/src/cms-components/core/page.js
+++ b/packages/sdk/src/cms-components/core/page.js
@@ -118,10 +118,12 @@ export default class CmsPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props.request.path !== prevProps.request.path) {
+    if (this.props.request.path !== prevProps.request.path && !this.props.pageModel) {
       const parsedUrl = parseRequest(this.props.request);
       Object.assign(this.state, parsedUrl);
       this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview);
+    } else if (this.props.pageModel !== prevProps.pageModel) {
+      this.updatePageModel(this.props.pageModel);
     }
 
     if (this.state.pageModel !== prevState.pageModel && this.cms) {

--- a/packages/sdk/src/cms-components/core/page.js
+++ b/packages/sdk/src/cms-components/core/page.js
@@ -51,7 +51,10 @@ export default class CmsPage extends React.Component {
   }
 
   updatePageModel(pageModel) {
-    addBodyComments(pageModel.page, this.state.preview);
+    if (pageModel) {
+      addBodyComments(pageModel.page, this.state.preview);
+    }
+
     this.setState({
       pageModel,
     });
@@ -118,12 +121,11 @@ export default class CmsPage extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.props.request.path !== prevProps.request.path && !this.props.pageModel) {
-      const parsedUrl = parseRequest(this.props.request);
-      Object.assign(this.state, parsedUrl);
-      this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview);
-    } else if (this.props.pageModel !== prevProps.pageModel) {
+    if (this.props.pageModel !== prevProps.pageModel) {
       this.updatePageModel(this.props.pageModel);
+    } else if (this.props.request.path !== prevProps.request.path) {
+      const parsedUrl = parseRequest(this.props.request);
+      this.fetchPageModel(parsedUrl.path, parsedUrl.query, parsedUrl.preview);
     }
 
     if (this.state.pageModel !== prevState.pageModel && this.cms) {


### PR DESCRIPTION
I have been making changes since my last pull request. 
I do agree with your points mentioned. 
Although the pageModel fetch shouldn't be handled by this SDK when the request changes as we lose several features NextJS provides.
The only difference with the current version of the SDK is the bypass of the fetch function , which fetches the pageModel and calls the `this.updatePageModel` function. The code will update the updatePageModel directly if this prop is present.

**Why this change**
- To make full use of the NextJS Router, the page should be fetched in the getIntialProps function of NextJS.
- At this point there is no other option to provide the user with a loader of some sort when they click a link. Which makes the page feel slow and non intuitive. 
- The Browser doesn't show a loading indicator either in the tab.
- According to the readme the presence of pageModel on the Page component should stop the SDK from fetching the pageModel itself.

**What is different compared to the previous pull request**
- Only the presence of PageModel will stop the fetch, instead of adding an extra property
- No changes have been done to the server-side example, as it still functions
- The readme hasn't been updated as it already contains this information