### PR TITLE
Fix object type check

### DIFF
--- a/examples/client-side-rendered/package.json
+++ b/examples/client-side-rendered/package.json
@@ -1,10 +1,10 @@
 {
   "name": "bloomreach-experience-react-sdk-csr-example",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Example client-side React App for the Bloomreach Experience SDK for React",
   "private": true,
   "dependencies": {
-    "bloomreach-experience-react-sdk": "^0.6.3",
+    "bloomreach-experience-react-sdk": "^0.6.4",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",

--- a/examples/server-side-rendered/package.json
+++ b/examples/server-side-rendered/package.json
@@ -1,12 +1,12 @@
 {
   "name": "bloomreach-experience-react-sdk-ssr-example",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Example server-side React App for the Bloomreach Experience SDK for React",
   "private": true,
   "author": "Bloomreach B.V.",
   "license": "Apache-2.0",
   "dependencies": {
-    "bloomreach-experience-react-sdk": "^0.6.3",
+    "bloomreach-experience-react-sdk": "^0.6.4",
     "dotenv": "^8.2.0",
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.1.6",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -486,6 +486,9 @@ Parses date-field of a content item and returns date as a string.
 
 ## Release notes
 
+### Version 0.6.4
+- Fix bug in the object type check in the `findChildById` function.
+
 ### Version 0.6.3
 - Add support of fully-qualified resource links.
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bloomreach-experience-react-sdk",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Bloomreach Experience SDK for React",
   "keywords": [
     "bloomreach",

--- a/packages/sdk/src/utils/find-child-by-id.js
+++ b/packages/sdk/src/utils/find-child-by-id.js
@@ -21,7 +21,7 @@ export default function findChildById(object, id, parent, idx) {
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < props.length; i++) {
     const prop = props[i];
-    if (typeof object[prop] === 'object') {
+    if (typeof object[prop] === 'object' && object[prop] !== null) {
       const result = findChildById(object[prop], id, object, prop);
       if (result) {
         return result;


### PR DESCRIPTION
This pull-request fixes a bug in the object type check in the `findChildById` function.